### PR TITLE
[Android] Allow to start a native fragment via Navigator.startNative().

### DIFF
--- a/example/android/app/src/main/java/com/airbnb/android/react/navigation/example/MainActivity.java
+++ b/example/android/app/src/main/java/com/airbnb/android/react/navigation/example/MainActivity.java
@@ -3,12 +3,13 @@ package com.airbnb.android.react.navigation.example;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 
-import com.airbnb.android.react.navigation.ScreenCoordinatorLayout;
 import com.airbnb.android.react.navigation.ReactAwareActivity;
 import com.airbnb.android.react.navigation.ScreenCoordinator;
 import com.airbnb.android.react.navigation.ScreenCoordinatorComponent;
+import com.airbnb.android.react.navigation.ScreenCoordinatorLayout;
 
 public class MainActivity extends ReactAwareActivity implements ScreenCoordinatorComponent {
+
   private static final String TAG = MainActivity.class.getSimpleName();
 
   private ScreenCoordinator screenCoordinator;
@@ -19,10 +20,23 @@ public class MainActivity extends ReactAwareActivity implements ScreenCoordinato
     setContentView(R.layout.activity_main);
     ScreenCoordinatorLayout container = (ScreenCoordinatorLayout) findViewById(R.id.content);
     screenCoordinator = new ScreenCoordinator(this, container, savedInstanceState);
+    screenCoordinator.registerScreen("NativeFragment2", Native2Fragment.FACTORY);
 
     if (savedInstanceState == null) {
       screenCoordinator.presentScreen(MainFragment.newInstance());
     }
+  }
+
+  @Override
+  protected void onResume() {
+    super.onResume();
+    screenCoordinator.onResume();
+  }
+
+  @Override
+  protected void onPause() {
+    screenCoordinator.onPause();
+    super.onPause();
   }
 
   @Override

--- a/example/android/app/src/main/java/com/airbnb/android/react/navigation/example/MainApplication.java
+++ b/example/android/app/src/main/java/com/airbnb/android/react/navigation/example/MainApplication.java
@@ -1,6 +1,7 @@
 package com.airbnb.android.react.navigation.example;
 
 import android.app.Application;
+
 import com.airbnb.android.react.navigation.NativeNavigationPackage;
 import com.airbnb.android.react.navigation.ReactNavigationCoordinator;
 import com.facebook.react.ReactApplication;
@@ -22,7 +23,7 @@ public class MainApplication extends Application implements ReactApplication {
 
     @Override
     protected List<ReactPackage> getPackages() {
-      return Arrays.<ReactPackage>asList(
+      return Arrays.asList(
           new MainReactPackage(),
           new NativeNavigationPackage()
       );
@@ -48,5 +49,4 @@ public class MainApplication extends Application implements ReactApplication {
     coordinator.injectReactInstanceManager(mReactNativeHost.getReactInstanceManager());
     coordinator.start(this);
   }
-
 }

--- a/example/android/app/src/main/java/com/airbnb/android/react/navigation/example/Native2Fragment.java
+++ b/example/android/app/src/main/java/com/airbnb/android/react/navigation/example/Native2Fragment.java
@@ -1,0 +1,46 @@
+package com.airbnb.android.react.navigation.example;
+
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.airbnb.android.react.navigation.NativeScreenFactory;
+
+public class Native2Fragment extends Fragment {
+  static final NativeScreenFactory FACTORY = new NativeScreenFactory() {
+    @NonNull
+    @Override
+    public Fragment newScreen(@Nullable Bundle props) {
+      return new Native2Fragment();
+    }
+  };
+
+  @Nullable
+  @Override
+  public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {
+    return inflater.inflate(R.layout.fragment_native_2, container, false);
+  }
+
+  @Override
+  public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+
+    Toolbar toolbar = (Toolbar) view.findViewById(R.id.toolbar);
+    ((AppCompatActivity) getActivity()).setSupportActionBar(toolbar);
+    toolbar.setTitle("Native Fragment");
+    toolbar.setNavigationIcon(R.drawable.n2_ic_arrow_back_white);
+    toolbar.setNavigationOnClickListener(new View.OnClickListener() {
+      @Override
+      public void onClick(View v) {
+        getActivity().onBackPressed();
+      }
+    });
+  }
+}

--- a/example/android/app/src/main/res/layout/fragment_native_2.xml
+++ b/example/android/app/src/main/res/layout/fragment_native_2.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@android:color/white"
+    android:orientation="vertical">
+
+    <android.support.v7.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/color_primary"
+        android:minHeight="?attr/actionBarSize"
+        app:theme="@style/ToolbarTheme" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_gravity="center"
+        android:gravity="center"
+        android:text="Second Native Fragment" />
+</LinearLayout>

--- a/example/screens/NavigationExampleScreen.js
+++ b/example/screens/NavigationExampleScreen.js
@@ -56,6 +56,10 @@ export default class NavigationExampleScreen extends Component {
           title="Navigation bar customisation"
           onPress={() => Navigator.push('NavigationBar')}
         />
+        <Row
+          title="Start Native Screen 2"
+          onPress={() => Navigator.push('NativeFragment2')}
+        />
       </Screen>
     );
   }

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/NativeScreenFactory.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/NativeScreenFactory.java
@@ -1,0 +1,14 @@
+package com.airbnb.android.react.navigation;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+
+public interface NativeScreenFactory {
+  /**
+   * Creates a new {@linkplain Fragment native screen} with {@code props}.
+   */
+  @NonNull
+  Fragment newScreen(@Nullable Bundle props);
+}

--- a/lib/android/src/main/java/com/airbnb/android/react/navigation/NavigatorModule.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/navigation/NavigatorModule.java
@@ -18,8 +18,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static com.airbnb.android.react.navigation.ReactNativeIntents.EXTRA_IS_DISMISS;
-import static com.airbnb.android.react.navigation.ScreenCoordinator.EXTRA_PAYLOAD;
 import static com.airbnb.android.react.navigation.ReactNativeUtils.VERSION_CONSTANT_KEY;
+import static com.airbnb.android.react.navigation.ScreenCoordinator.EXTRA_PAYLOAD;
 
 class NavigatorModule extends ReactContextBaseJavaModule {
   private static final int VERSION = 2;
@@ -113,8 +113,13 @@ class NavigatorModule extends ReactContextBaseJavaModule {
     if (activity == null) {
       return;
     }
-    Intent intent = coordinator.intentForKey(activity.getBaseContext(), name, props);
-    startActivityWithPromise(activity, intent, promise, options);
+
+    boolean startedFragment = coordinator.startFragmentForKey(name, props, options);
+
+    if (!startedFragment) {
+      Intent intent = coordinator.intentForKey(activity.getBaseContext(), name, props);
+      startActivityWithPromise(activity, intent, promise, options);
+    }
   }
 
   @SuppressWarnings("UnusedParameters")


### PR DESCRIPTION
* Introduces NativeScreenFactory for android.support.v4.app.Fragment.
* Changes NavigatorModule.pushNative() to check for native screen availability.
* Adds Native2Fragment to example app to show case usage of the new api.
* ReactNavigationCoordinator throws exceptions early if no activity where registered.